### PR TITLE
Fix KeyboardLayoutGuide bug

### DIFF
--- a/Pod/Classes/Keyboard/UIView+KeyboardLayoutGuide.swift
+++ b/Pod/Classes/Keyboard/UIView+KeyboardLayoutGuide.swift
@@ -68,8 +68,13 @@ public extension UIView {
 
         Keyboard.addFrameObserver(guide) { [weak self] keyboardFrame in
             if let sself = self where sself.window != nil {
-                let convertedFrame = sself.convertRect(keyboardFrame, fromView: nil)
-                topConstraint.constant = -(UIScreen.mainScreen().bounds.maxY - convertedFrame.minY)
+                var frameInWindow = sself.frame
+
+                if let superview = sself.superview {
+                    frameInWindow = superview.convertRect(sself.frame, toView: nil)
+                }
+
+                topConstraint.constant = -(frameInWindow.maxY - keyboardFrame.minY)
 
                 sself.layoutIfNeeded()
             }

--- a/Pod/Classes/Keyboard/UIView+KeyboardLayoutGuide.swift
+++ b/Pod/Classes/Keyboard/UIView+KeyboardLayoutGuide.swift
@@ -74,7 +74,7 @@ public extension UIView {
                     frameInWindow = superview.convertRect(sself.frame, toView: nil)
                 }
 
-                topConstraint.constant = -(frameInWindow.maxY - keyboardFrame.minY)
+                topConstraint.constant = min(0.0, -(frameInWindow.maxY - keyboardFrame.minY))
 
                 sself.layoutIfNeeded()
             }


### PR DESCRIPTION
KeyboardLayoutGuide should be converting the view's frame to window coordinates to do math with keyboard frame. This fixes an issue with incorrect constraint constants when the view was not full screen.