### PR TITLE
Sort Acknowledgements

### DIFF
--- a/Pod/Classes/Acknowledgements/AcknowlegementsListViewModel.swift
+++ b/Pod/Classes/Acknowledgements/AcknowlegementsListViewModel.swift
@@ -71,8 +71,8 @@ private extension AcknowledgementsListViewModel {
             return []
         }
         // First and last elements in the settings bundle are not needed (title and empty row).
-        let acknowledgements = specifiers.suffix(from: 1).dropLast().flatMap(AcknowledgementViewModel.init(dictionary:)).sorted {
-          return $0.title < $1.title
+        let acknowledgements = specifiers[1..<specifiers.count-1].flatMap(AcknowledgementViewModel.init(dictionary:)).sorted {
+          return $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
         }
 
         return acknowledgements

--- a/Pod/Classes/Acknowledgements/AcknowlegementsListViewModel.swift
+++ b/Pod/Classes/Acknowledgements/AcknowlegementsListViewModel.swift
@@ -71,7 +71,10 @@ private extension AcknowledgementsListViewModel {
             return []
         }
         // First and last elements in the settings bundle are not needed (title and empty row).
-        let acknowledgements = specifiers.suffix(from: 1).dropLast().flatMap(AcknowledgementViewModel.init(dictionary:))
+        let acknowledgements = specifiers.suffix(from: 1).dropLast().flatMap(AcknowledgementViewModel.init(dictionary:)).sorted {
+          return $0.title < $1.title
+        }
+
         return acknowledgements
     }
 


### PR DESCRIPTION
CocoaPods doesn't sort acknowledgements alphabetically (see attachment). Apply a simple sort based on name.

![simulator screen shot nov 23 2016 2 32 33 pm](https://cloud.githubusercontent.com/assets/362805/20575984/c7dec4e4-b189-11e6-8d9d-d3dde3ef2cd2.png)
