### PR TITLE
Stop calling .init explicitly.

### DIFF
--- a/Example/Swiftilities/App Delegate/AppDelegate.swift
+++ b/Example/Swiftilities/App Delegate/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
-        DefaultBehaviors.init(behaviors: [LogAppearanceBehavior()]).inject()
+        DefaultBehaviors(behaviors: [LogAppearanceBehavior()]).inject()
         return true
     }
 }


### PR DESCRIPTION
It's a trivial change, but it sets a bad precedent for those using the example app as guidance.