### PR TITLE
Allow Math subspec to run on all platforms

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,6 +8,4 @@ end
 
 target 'Swiftilities_Tests' do
   pod 'Swiftilities', :path => '../'
-
-
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,6 +4,7 @@ PODS:
   - Swiftilities/AboutView (0.18.0)
   - Swiftilities/AccessibilityHelpers (0.18.0)
   - Swiftilities/Acknowledgements (0.18.0):
+    - Swiftilities/Compatibility
     - Swiftilities/Deselection
     - Swiftilities/LicenseFormatter
   - Swiftilities/All (0.18.0):
@@ -67,7 +68,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Swiftilities: 113ea123dc5e5d55df384474a2918b2077208a49
+  Swiftilities: 8c0ea8e724613c4a8521bdbaa74ae4eeb46ed3b9
 
 PODFILE CHECKSUM: b1d3049f81e75c3304f48a3fb9386cc1458c9549
 

--- a/Example/Pods/Local Podspecs/Swiftilities.podspec.json
+++ b/Example/Pods/Local Podspecs/Swiftilities.podspec.json
@@ -41,6 +41,9 @@
         ],
         "Swiftilities/Deselection": [
 
+        ],
+        "Swiftilities/Compatibility": [
+
         ]
       },
       "source_files": "Pod/Classes/Acknowledgements/*.swift",
@@ -166,7 +169,24 @@
     },
     {
       "name": "Math",
-      "source_files": "Pod/Classes/Math/*.swift"
+      "platforms": {
+        "ios": "9.0",
+        "tvos": "9.0",
+        "osx": "10.11",
+        "watchos": "2.2"
+      },
+      "ios": {
+        "source_files": "Pod/Classes/Math/*.swift"
+      },
+      "tvos": {
+        "source_files": "Pod/Classes/Math/*.swift"
+      },
+      "osx": {
+        "source_files": "Pod/Classes/Math/*.swift"
+      },
+      "watchos": {
+        "source_files": "Pod/Classes/Math/*.swift"
+      }
     },
     {
       "name": "RootViewController",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -4,6 +4,7 @@ PODS:
   - Swiftilities/AboutView (0.18.0)
   - Swiftilities/AccessibilityHelpers (0.18.0)
   - Swiftilities/Acknowledgements (0.18.0):
+    - Swiftilities/Compatibility
     - Swiftilities/Deselection
     - Swiftilities/LicenseFormatter
   - Swiftilities/All (0.18.0):
@@ -67,7 +68,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Swiftilities: 113ea123dc5e5d55df384474a2918b2077208a49
+  Swiftilities: 8c0ea8e724613c4a8521bdbaa74ae4eeb46ed3b9
 
 PODFILE CHECKSUM: b1d3049f81e75c3304f48a3fb9386cc1458c9549
 

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     declarative-option (0.1.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.4.0)
+    dotenv (2.5.0)
     emoji_regex (0.1.1)
     escape (0.0.4)
     excon (0.62.0)

--- a/Pod/Classes/Math/CubicBezier.swift
+++ b/Pod/Classes/Math/CubicBezier.swift
@@ -12,8 +12,6 @@
  This licensed material is licensed under the Apache 2.0 license. http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-import UIKit
-
 // swiftlint:disable identifier_name
 extension CubicBezier {
 

--- a/Pod/Classes/Math/CubicBezier.swift
+++ b/Pod/Classes/Math/CubicBezier.swift
@@ -12,6 +12,8 @@
  This licensed material is licensed under the Apache 2.0 license. http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+import CoreGraphics.CGGeometry
+
 // swiftlint:disable identifier_name
 extension CubicBezier {
 

--- a/Pod/Classes/Math/CurveProvider.swift
+++ b/Pod/Classes/Math/CurveProvider.swift
@@ -6,7 +6,7 @@
 //
 //
 
-import Foundation
+import CoreGraphics.CGBase
 
 public protocol CurveProvider {
 
@@ -14,6 +14,7 @@ public protocol CurveProvider {
 
 }
 
+#if os(iOS)
 @available(iOS 10.0, *)
 extension UICubicTimingParameters: CurveProvider {
 
@@ -57,6 +58,7 @@ extension UIViewAnimationCurve: CurveProvider {
     }
 
 }
+#endif
 
 extension BinaryFloatingPoint {
 

--- a/Swiftilities.podspec
+++ b/Swiftilities.podspec
@@ -148,7 +148,17 @@ Pod::Spec.new do |s|
   # Math
 
   s.subspec "Math" do |ss|
-    ss.source_files = "Pod/Classes/Math/*.swift"
+    ss.ios.deployment_target = '9.0'
+    ss.ios.source_files = "Pod/Classes/Math/*.swift"
+
+    ss.tvos.deployment_target = '9.0'
+    ss.tvos.source_files = "Pod/Classes/Math/*.swift"
+
+    ss.osx.deployment_target = '10.11'
+    ss.osx.source_files = "Pod/Classes/Math/*.swift"
+
+    ss.watchos.deployment_target = '2.2'
+    ss.watchos.source_files = "Pod/Classes/Math/*.swift"
   end
 
   # RootViewController


### PR DESCRIPTION
Since there was no dependence on UIKit/AppKit, this was easy. Wanted to use the scaling functions in my juggling app.